### PR TITLE
[WFENG-2551] go straight to vault for SSO

### DIFF
--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -242,7 +242,7 @@ const routeForAuthorizationCodeFlow = (
  * @modifies adds items to browser localStorage and sessionStorage
  *
  */
-const routeForImplicitFlow = (
+export const routeForImplicitFlow = (
   settings: Settings,
   currentSearchParams: URLSearchParams,
   originUrl: string,

--- a/src/routes/(app)/+layout.ts
+++ b/src/routes/(app)/+layout.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit';
+import { InvalidTokenError, jwtDecode, type JwtPayload } from 'jwt-decode';
 
 import type { LayoutData, LayoutLoad } from './$types';
 
@@ -18,6 +19,7 @@ import {
   maybeRouteForOIDCImplicitCallback,
   type OIDCCallback,
   OIDCImplicitCallbackError,
+  routeForImplicitFlow,
   routeForLoginPage,
 } from '$lib/utilities/route-for';
 
@@ -77,6 +79,40 @@ export const load: LayoutLoad = async function ({
   }
 
   const user = getAuthUser();
+
+  // hello hackness my old friend
+  // i've come to auth with you again
+  // because a session softly stale-ing
+  // left itself while devs were sleeping
+  // and the token that was planted yesterday
+  // still remains
+  // within the sound of login
+  //
+  // 🎵 to the tune of "The Sound of Silence" 🎵
+  //
+  // save the redirect and the click through the login page, iff there is an expired id token.
+  // the login page is still used to display auth errors (e.g. UI proxy)
+  if (user?.idToken) {
+    let token: JwtPayload;
+    try {
+      token = jwtDecode(user.idToken);
+    } catch (e) {
+      if (e instanceof InvalidTokenError) {
+        clearAuthUser();
+      }
+
+      throw e;
+    }
+
+    if (token?.exp && token.exp * 1000 <= Date.now()) {
+      clearAuthUser();
+      const location = new URL(document.location.toString());
+      redirect(
+        302,
+        routeForImplicitFlow(settings, location.searchParams, location.origin),
+      );
+    }
+  }
 
   if (!isAuthorized(settings, user)) {
     redirect(302, routeForLoginPage());


### PR DESCRIPTION
At least one less SSO click per day. Customer ask.

When a stale ID token is found, transparently triggers the Vault OIDC flow rather than requiring a user click through (shown below).

<img width="1563" alt="Screenshot 2024-06-27 at 4 31 04 PM" src="https://github.com/DataDog/temporalio-ui/assets/22668869/1d4fb843-4fbd-41c2-9205-efff3ca39871">

Following the standard procedure (e.g. https://github.com/DataDog/dd-source/pull/104445).

## Test Plan

### Self

```
// from the console, set a stale token
localStorage.setItem("AuthUser", '{"idToken":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjY3YWEyNmIxLTMzODQtZGEzMi04M2E4LWIyOGMwMDU4MDI3YyJ9.eyJhdWQiOiAiYXRsYXMtc3RhZ2luZyIsICJkYXRhY2VudGVyIjogInVzMS5kZGJ1aWxkLmlvIiwgImVtYWlsIjogImJyZW5kYW4uZ2Vycml0eUBkYXRhZG9naHEuY29tIiwgImV4cCI6IDEwMCwgImdyb3VwcyI6IFtdfQo.aGE8Z2oH8NKq9X_3ivuaXsc2J_WSh71tT4_HQZlEHDPBP87uX6lYVITjLTCQSYpA5sABqmFCLHpL6VAMC9B53cFk4j5D9Gxg7pFfnVbPfafSg4iuaoB4AzAd_Gyyzf2cEzxqWcl1oaxTti69EcsjE-BronbnY74k8sGMsegKjqormsHg4QsuzOOY8q2ZPtU1pYuslCY0QeBbtfBb9vInsSocopREptl20q37e3QRGRV0031mn2ZR4qW0zM7YD1IstbUDWJioDAl2cpJL-VoUkqrRCCfUbNFBaKcQHurJMRCopRcK999499XSNR423VcbAFc9ezFim5al6uGBOHTrDw=","name":"brendan.gerrity","email":"brendan.gerrity@datadoghq.com"}');
```

Refresh and watch the console to see the redirect. Shouldn't see the login page.

Tested both with and without proxy in gizmo.

### Non-Domains Authorized

```
kubectl port-forward deployments/temporal-ui-server 8080:8080 --namespace atlas-dev --context gizmo.us1.staging.dog

# hit http://localhost:8080/
# screenshot

# chrome dev console
localStorage.setItem("AuthUser", '{"idToken":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjY3YWEyNmIxLTMzODQtZGEzMi04M2E4LWIyOGMwMDU4MDI3YyJ9.eyJhdWQiOiAiYXRsYXMtc3RhZ2luZyIsICJkYXRhY2VudGVyIjogInVzMS5kZGJ1aWxkLmlvIiwgImVtYWlsIjogImJyZW5kYW4uZ2Vycml0eUBkYXRhZG9naHEuY29tIiwgImV4cCI6IDEwMCwgImdyb3VwcyI6IFtdfQo.aGE8Z2oH8NKq9X_3ivuaXsc2J_WSh71tT4_HQZlEHDPBP87uX6lYVITjLTCQSYpA5sABqmFCLHpL6VAMC9B53cFk4j5D9Gxg7pFfnVbPfafSg4iuaoB4AzAd_Gyyzf2cEzxqWcl1oaxTti69EcsjE-BronbnY74k8sGMsegKjqormsHg4QsuzOOY8q2ZPtU1pYuslCY0QeBbtfBb9vInsSocopREptl20q37e3QRGRV0031mn2ZR4qW0zM7YD1IstbUDWJioDAl2cpJL-VoUkqrRCCfUbNFBaKcQHurJMRCopRcK999499XSNR423VcbAFc9ezFim5al6uGBOHTrDw=","name":"brendan.gerrity","email":"brendan.gerrity@datadoghq.com"}');

# again, hit http://localhost:8080/
# screenshot

# chrome dev console
localStorage.getItem("AuthUser")
# copy output
```

## Risks

There may be some security conventions or best practices that users should click or take an active step.
