### PR TITLE
[WFENG-2560] backport fix for excess children in relationships tab

### DIFF
--- a/src/lib/components/workflow/workflow-relationships.svelte
+++ b/src/lib/components/workflow/workflow-relationships.svelte
@@ -17,13 +17,13 @@
   import ParentWorkflowTable from './parent-workflow-table.svelte';
   import SchedulerTable from './scheduler-table.svelte';
 
-  $: ({ workflow: workflowId, namespace } = $page.params);
+  $: ({ workflow: workflowId, run: runId, namespace } = $page.params);
   $: ({ workflow } = $workflowRun);
 
   let liveChildren: WorkflowExecution[] = [];
 
   onMount(async () => {
-    liveChildren = await fetchAllChildWorkflows(namespace, workflowId);
+    liveChildren = await fetchAllChildWorkflows(namespace, workflowId, runId);
   });
 
   $: workflowRelationships = getWorkflowRelationships(

--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -41,7 +41,11 @@
         (id) => id.workflowId !== workflow.id && id.runId !== workflow.runId,
       );
     } else {
-      const children = await fetchAllChildWorkflows(namespace, workflow.id);
+      const children = await fetchAllChildWorkflows(
+        namespace,
+        workflow.id,
+        workflow.runId,
+      );
       childrenIds = [
         { workflowId: workflow.id, runId: workflow.runId, children },
         ...childrenIds,

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -386,14 +386,17 @@ export async function fetchWorkflowForSchedule(
 export async function fetchAllChildWorkflows(
   namespace: string,
   workflowId: string,
+  runId?: string,
 ): Promise<WorkflowExecution[]> {
   if (!get(canFetchChildWorkflows)) {
     return [];
   }
   try {
-    const { workflows } = await fetchAllWorkflows(namespace, {
-      query: `ParentWorkflowId = "${workflowId}"`,
-    });
+    let query = `ParentWorkflowId = "${workflowId}"`;
+    if (runId) {
+      query += ` AND ParentRunId = "${runId}"`;
+    }
+    const { workflows } = await fetchAllWorkflows(namespace, { query });
     return workflows;
   } catch (e) {
     return [];


### PR DESCRIPTION
The `Relationships` was previously showing all children of the parent workflow rather than the children of the parent run.

## Test Plan

Deployed to `atlas-staging` and confirmed different children between runs shown.