### PR TITLE
Revert "[WFENG-2551] go straight to vault for SSO (#5)"

### DIFF
--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -242,7 +242,7 @@ const routeForAuthorizationCodeFlow = (
  * @modifies adds items to browser localStorage and sessionStorage
  *
  */
-export const routeForImplicitFlow = (
+const routeForImplicitFlow = (
   settings: Settings,
   currentSearchParams: URLSearchParams,
   originUrl: string,


### PR DESCRIPTION
Reverts DataDog/temporalio-ui#5 to address user reports about the autologin not taking them to their workflow. Now users will need to click the login button once a day but they will get to go to their workflow after clicking that button but that is an easier fix for now than doing insecure vault things

### Test Plan
Deployed to gizmo
`bzl run //domains/atlas/apps/temporal/config/k8s/temporal-server:temporal.atlas-dev.gizmo.us1.staging.dog`
Then port forwarded the UI
`kubectl port-forward deployments/temporal-ui 8080:8080 --context gizmo.us1.staging.dog --namespace atlas-dev`    
Delete the `AuthUser` token in `localStorage` for localhost:8080
Then navigate to  http://localhost:8080/namespaces/default/workflows/maru.BasicLoadService_BasicWorkflow-d645a5be-21da-41d0-b7fc-f4ea5b30db78-0-0-86398/4876fe2c-e299-42c5-af25-59fdd8295e9e/history
After clicking the login button you will be taken to the workflow

Only **after** testing this change works in gizmo, tested in staging for Domains as this serves user traffic (outstanding issue tracked in https://datadoghq.atlassian.net/browse/WFENG-2718)
Deployed temporal-ui-server in stripe staging
`bzl run //domains/atlas/apps/temporal/config/k8s/temporal-ui:temporal-ui-server.atlas.stripe.us1.staging.dog`
Delete the `AuthUser` token in `localStorage` for https://temporal.us1.staging.dog
Then navigate to https://temporal.us1.staging.dog/namespaces/v1:oncall-0/workflows/99b63f12-1927-4802-a9b3-19f875cdeb9e_10/127c7709-0b5e-4a0e-938e-be0c3d2cecc6/history
After clicking the login button you will be taken to the workflow

### Documentation
Wrote https://datadoghq.atlassian.net/wiki/spaces/ATLAS/pages/4193290473/Testing+Changes+with+the+Temporal+UI+Fork to better explain how to test changes