### PR TITLE
Allow query path on disableWriteActions

### DIFF
--- a/server/server/route/api.go
+++ b/server/server/route/api.go
@@ -24,6 +24,7 @@ package route
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 
@@ -39,7 +40,19 @@ func DisableWriteMiddleware(cfgProvider *config.ConfigProviderWithRefresh) echo.
 				return c.JSON(http.StatusInternalServerError, err)
 			}
 
-			if cfg.DisableWriteActions && c.Request().Method != http.MethodGet {
+			if c.Request().Method == http.MethodGet {
+				return next(c)
+			}
+
+			if cfg.DisableWriteActions {
+				path := c.Request().URL.Path
+				method := c.Request().Method
+
+				if method == http.MethodPost && strings.HasPrefix(path, "/api/v1/namespaces/") &&
+					strings.Contains(path, "/workflows/") && strings.Contains(path, "/query/") {
+					return next(c)
+				}
+
 				return echo.ErrMethodNotAllowed
 			}
 


### PR DESCRIPTION
Porting in https://github.com/temporalio/ui/pull/2601 to be able to see queries and stack traces when write actions are disabled in the Temporal UI