### PR TITLE
[WFENG-263] Adds SSO and auto login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ server/ui/assets
 /playwright/.cache/
 /dist
 /audits
+.idea/
 go.work
 go.work.sum

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "json-bigint": "^1.0.0",
     "just-debounce": "^1.1.0",
     "just-throttle": "^4.2.0",
+    "jwt-decode": "^4.0.0",
+    "lscache": "^1.3.2",
     "kebab-case": "^1.0.2",
     "lodash.groupby": "^4.6.0",
     "mdast-util-from-markdown": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -86,12 +86,18 @@ dependencies:
   just-throttle:
     specifier: ^4.2.0
     version: 4.2.0
+  jwt-decode:
+    specifier: ^4.0.0
+    version: 4.0.0
   kebab-case:
     specifier: ^1.0.2
     version: 1.0.2
   lodash.groupby:
     specifier: ^4.6.0
     version: 4.6.0
+  lscache:
+    specifier: ^1.3.2
+    version: 1.3.2
   mdast-util-from-markdown:
     specifier: ^2.0.1
     version: 2.0.1
@@ -12167,6 +12173,11 @@ packages:
     resolution: {integrity: sha512-/iAZv1953JcExpvsywaPKjSzfTiCLqeguUTE6+VmK15mOcwxBx7/FHrVvS4WEErMR03TRazH8kcBSHqMagYIYg==}
     dev: false
 
+  /jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+    dev: false
+
   /kebab-case@1.0.2:
     resolution: {integrity: sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q==}
     dev: false
@@ -12436,6 +12447,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /lscache@1.3.2:
+    resolution: {integrity: sha512-CBZT/pDcaK3I3XGwDLaszDe8hj0pCgbuxd3W79gvHApBSdKVXvR9fillbp6eLvp7dLgtaWm3a1mvmhAqn9uCXQ==}
+    dev: false
 
   /lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -21,23 +21,18 @@ startWorkflowDisabled: false
 hideWorkflowQueryErrors: false
 refreshWorkflowCountsDisabled: false
 auth:
-  enabled: false
-  providers:
-    - label: Auth0 oidc # for internal use; in future may expose as button text
-      type: oidc # for futureproofing; only oidc is supported today
-      providerUrl: https://myorg.us.auth0.com/
-      issuerUrl: "" # needed if the Issuer Url and the Provider Url are different
-      clientId: xxxxxxxxxxxxxxxxxxxx
-      clientSecret: xxxxxxxxxxxxxxxxxxxx
+  enabled: true
+  providers:  # only the first is used. second is provided for reference
+    - label: oidc implicit flow
+      type: oidc
+      flow: implicit
+      # TODO: support optional issuer validation
+      authorizationUrl: https://vault.us1.ddbuild.io/v1/auth/oidc-provider/authorization
+      clientId: atlas
       scopes:
         - openid
         - profile
         - email
-      callbackUrl: http://localhost:8080/auth/sso/callback
-      options: # added as URL query params when redirecting to auth provider
-        audience: myorg-dev
-        organization: org_xxxxxxxxxxxx
-        invitation:
 tls:
   caFile:
   certFile:

--- a/server/docker/README.md
+++ b/server/docker/README.md
@@ -15,6 +15,7 @@ docker run \
     -e TEMPORAL_ADDRESS=127.0.0.1:7233 \
     -e TEMPORAL_UI_PORT=8080 \
     -e TEMPORAL_AUTH_ENABLED=true \
+    -e TEMPORAL_AUTH_FLOW_TYPE=authorization-code \
     -e TEMPORAL_AUTH_PROVIDER_URL=https://accounts.google.com \
     -e TEMPORAL_AUTH_CLIENT_ID=xxxxx-xxxx.apps.googleusercontent.com \
     -e TEMPORAL_AUTH_CLIENT_SECRET=xxxxxxxxxxxxxxx \

--- a/server/docker/config-template.yaml
+++ b/server/docker/config-template.yaml
@@ -42,8 +42,10 @@ auth:
   providers:
   - label: {{ default .Env.TEMPORAL_AUTH_LABEL "sso" }}
     type: {{ default .Env.TEMPORAL_AUTH_TYPE "oidc" }}
+    flow: {{ default .Env.TEMPORAL_AUTH_FLOW_TYPE "authorization-code" }}
     providerUrl: {{ .Env.TEMPORAL_AUTH_PROVIDER_URL }}
     issuerUrl: {{ default .Env.TEMPORAL_AUTH_ISSUER_URL "" }}
+    authorizationUrl: {{ default .Env.TEMPORAL_AUTH_AUTHORIZATION_URL "" }}
     clientId: {{ .Env.TEMPORAL_AUTH_CLIENT_ID }}
     clientSecret: {{ .Env.TEMPORAL_AUTH_CLIENT_SECRET }}
     callbackUrl: {{ .Env.TEMPORAL_AUTH_CALLBACK_URL }}

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -45,8 +45,14 @@ import (
 )
 
 type Auth struct {
-	Enabled bool
-	Options []string
+	Enabled          bool
+	Flow             string
+	ProviderURL      string
+	IssuerURL        string
+	AuthorizationURL string
+	ClientID         string
+	Scopes           []string
+	Options          []string
 }
 
 type CodecResponse struct {
@@ -115,17 +121,24 @@ func GetSettings(cfgProvider *config.ConfigProviderWithRefresh) func(echo.Contex
 		}
 
 		var options []string
+		var authProviderCfg config.AuthProvider
 		if len(cfg.Auth.Providers) != 0 {
-			authProviderCfg := cfg.Auth.Providers[0].Options
-			for k := range authProviderCfg {
+			authProviderCfg = cfg.Auth.Providers[0]
+			for k := range authProviderCfg.Options {
 				options = append(options, k)
 			}
 		}
 
 		settings := &SettingsResponse{
 			Auth: &Auth{
-				Enabled: cfg.Auth.Enabled,
-				Options: options,
+				Enabled:          cfg.Auth.Enabled,
+				Flow:             authProviderCfg.Flow,
+				ProviderURL:      authProviderCfg.ProviderURL,
+				IssuerURL:        authProviderCfg.IssuerURL,
+				AuthorizationURL: authProviderCfg.AuthorizationURL,
+				ClientID:         authProviderCfg.ClientID,
+				Scopes:           authProviderCfg.Scopes,
+				Options:          options,
 			},
 			BannerText:                  cfg.BannerText,
 			DefaultNamespace:            cfg.DefaultNamespace,

--- a/server/server/config/auth.go
+++ b/server/server/config/auth.go
@@ -52,16 +52,39 @@ func (c *AuthProvider) validate() error {
 		return nil
 	}
 
-	if c.ProviderURL == "" {
-		return errors.New("auth provider url is not")
+	switch flowType := c.Flow; flowType {
+	case "authorization-code":
+		if c.ProviderURL == "" {
+			return errors.New("auth provider url is not set")
+		}
+		if c.AuthorizationURL != "" {
+			return errors.New("auth endpoint url is not used in auth code flow")
+		}
+		if c.CallbackURL == "" {
+			return errors.New("auth callback url is not set")
+		}
+	case "implicit":
+		// TODO: support oidc discovery in implicit flow
+		if c.ProviderURL != "" {
+			return errors.New("auth provider url is not used in implicit flow")
+		}
+		// TODO: support optional issuer validation
+		if c.AuthorizationURL == "" {
+			return errors.New("auth issuer url is not set")
+		}
+		if c.ClientSecret != "" {
+			return errors.New("no secrets in implicit flow")
+		}
+		if c.CallbackURL != "" {
+			return errors.New("auth callback url is not used in implicit flow")
+		}
+
+	default:
+		return errors.New("auth oidc flow is not valid")
 	}
 
 	if c.ClientID == "" {
 		return errors.New("auth client id is not set")
-	}
-
-	if c.CallbackURL == "" {
-		return errors.New("auth callback url is not set")
 	}
 
 	return nil

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -101,15 +101,19 @@ type (
 		Label string `yaml:"label"`
 		// Type of the auth provider. Only OIDC is supported today
 		Type string `yaml:"type"`
-		// OIDC .well-known/openid-configuration URL, ex. https://accounts.google.com/
+		// OIDC login flow type. The "authorization-code" and "implicit" flows are supported.
+		Flow string `yaml:"flow"`
+		// OIDC .well-known/openid-configuration URL, e.g. https://accounts.google.com/. Discovery unsupported in implicit flow.
 		ProviderURL string `yaml:"providerUrl"`
-		// IssuerUrl - optional. Needed only when differs from the auth provider URL
-		IssuerUrl    string `yaml:"issuerUrl"`
-		ClientID     string `yaml:"clientId"`
-		ClientSecret string `yaml:"clientSecret"`
+		// Optional. Needed only when differs from the auth provider URL. In implicit flow, enables token issuer validation.
+		IssuerURL string `yaml:"issuerUrl"`
+		// Required for implicit flow. OIDC authorization endpoint URL, e.g. https://accounts.google.com/o/oauth2/v2/auth.
+		AuthorizationURL string `yaml:"authorizationUrl"`
+		ClientID         string `yaml:"clientId"`
+		ClientSecret     string `yaml:"clientSecret"`
 		// Scopes for auth. Typically [openid, profile, email]
 		Scopes []string `yaml:"scopes"`
-		// CallbackURL - URL for the callback URL, ex. https://localhost:8080/sso/callback
+		// URL for the callback, e.g. https://localhost:8080/sso/callback. Not used in the implicit flow.
 		CallbackURL string `yaml:"callbackUrl"`
 		// Options added as URL query params when redirecting to auth provider. Can be used to configure custom auth flows such as Auth0 invitation flow.
 		Options map[string]interface{} `yaml:"options"`

--- a/src/lib/holocene/user-menu.svelte
+++ b/src/lib/holocene/user-menu.svelte
@@ -19,7 +19,7 @@
   }
 </script>
 
-{#if $authUser.accessToken}
+{#if $authUser.idToken || $authUser.accessToken}
   <MenuContainer>
     <MenuButton variant="ghost" hasIndicator controls="user-menu">
       <img

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -20,6 +20,12 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
   const settingsInformation = {
     auth: {
       enabled: !!settingsResponse?.Auth?.Enabled,
+      flow: settingsResponse?.Auth?.Flow,
+      providerUrl: settingsResponse?.Auth?.ProviderURL,
+      issuerUrl: settingsResponse?.Auth?.IssuerURL,
+      authorizationUrl: settingsResponse?.Auth?.AuthorizationURL,
+      clientId: settingsResponse?.Auth?.ClientID,
+      scopes: settingsResponse?.Auth?.Scopes,
       options: settingsResponse?.Auth?.Options,
     },
     bannerText: settingsResponse?.BannerText,

--- a/src/lib/stores/auth-user.ts
+++ b/src/lib/stores/auth-user.ts
@@ -2,16 +2,27 @@ import { get } from 'svelte/store';
 
 import { persistStore } from '$lib/stores/persist-store';
 import type { User } from '$lib/types/global';
+import { OIDCFlow } from '$lib/types/global';
 
 export const authUser = persistStore<User>('AuthUser', {});
 
 export const getAuthUser = (): User => get(authUser);
 
-export const setAuthUser = (user: User) => {
+export const setAuthUser = (user: User, oidcFlow: OIDCFlow) => {
   const { accessToken, idToken, name, email, picture } = user;
 
-  if (!accessToken) {
-    throw new Error('No access token');
+  switch (oidcFlow) {
+    case OIDCFlow.AuthorizationCode:
+    default:
+      if (!accessToken) {
+        throw new Error('No access token');
+      }
+      break;
+    case OIDCFlow.Implicit:
+      if (!idToken) {
+        throw new Error('No id token');
+      }
+      break;
   }
 
   authUser.set({

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -71,9 +71,20 @@ export interface NetworkError {
   message?: string;
 }
 
+export enum OIDCFlow {
+  AuthorizationCode = 'authorization-code',
+  Implicit = 'implicit',
+}
+
 export type Settings = {
   auth: {
     enabled: boolean;
+    flow: OIDCFlow;
+    providerUrl: string;
+    issuerUrl: string;
+    authorizationUrl: string;
+    clientId: string;
+    scopes: string[];
     options: string[];
   };
   bannerText: string;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,5 +1,7 @@
 import type { google, temporal } from '@temporalio/proto';
 
+import type { OIDCFlow } from '$lib/types/global';
+
 // api.workflowservice
 
 export type DescribeNamespaceResponse =
@@ -237,7 +239,16 @@ export type Timestamp = google.protobuf.ITimestamp;
 
 // extra APIs
 export type SettingsResponse = {
-  Auth: { Enabled: boolean; Options: string[] };
+  Auth: {
+    Enabled: boolean;
+    Flow: OIDCFlow;
+    ProviderURL: string;
+    IssuerURL: string;
+    AuthorizationURL: string;
+    ClientID: string;
+    Scopes: string[];
+    Options: string[];
+  };
   BannerText: string;
   Codec: {
     Endpoint: string;

--- a/src/lib/utilities/is-authorized.test.ts
+++ b/src/lib/utilities/is-authorized.test.ts
@@ -2,20 +2,24 @@ import { describe, expect, it } from 'vitest';
 
 import { isAuthorized } from './is-authorized';
 
-const user = {
-  accessToken: 'xxx',
+const codeUser = {
+  accessToken: 'accessToken',
+};
+
+const implicitUser = {
+  idToken: 'idToken',
 };
 
 const noUser = {
   name: 'name',
   email: 'email',
   picture: 'picture',
-  idToken: 'idToken',
 };
 
-const getSettings = (enabled: boolean) => ({
+const getSettings = (enabled: boolean, flow: string) => ({
   auth: {
     enabled,
+    flow,
     options: [],
   },
   baseUrl: 'www.base.com',
@@ -29,16 +33,40 @@ const getSettings = (enabled: boolean) => ({
 });
 
 describe('isAuthorized', () => {
-  it('should return true if auth no enabled and no user', () => {
-    expect(isAuthorized(getSettings(false), noUser)).toBe(true);
+  it('should return true if auth not enabled and no user', () => {
+    expect(isAuthorized(getSettings(false, 'authorization-code'), noUser)).toBe(
+      true,
+    );
   });
-  it('should return true if auth no enabled and user', () => {
-    expect(isAuthorized(getSettings(false), user)).toBe(true);
+  it('should return true if auth not enabled and user', () => {
+    expect(
+      isAuthorized(getSettings(false, 'authorization-code'), codeUser),
+    ).toBe(true);
   });
-  it('should return false if auth enabled and no user', () => {
-    expect(isAuthorized(getSettings(true), noUser)).toBe(false);
+  it('should return false if code auth enabled and no user', () => {
+    expect(isAuthorized(getSettings(true, 'authorization-code'), noUser)).toBe(
+      false,
+    );
   });
-  it('should return true if auth enabled and user', () => {
-    expect(isAuthorized(getSettings(true), user)).toBe(true);
+  it('should return false if code auth enabled and implicit user', () => {
+    expect(
+      isAuthorized(getSettings(true, 'authorization-code'), implicitUser),
+    ).toBe(false);
+  });
+  it('should return true if code auth enabled and code user', () => {
+    expect(
+      isAuthorized(getSettings(true, 'authorization-code'), codeUser),
+    ).toBe(true);
+  });
+  it('should return false if implicit auth enabled and no user', () => {
+    expect(isAuthorized(getSettings(true, 'implicit'), noUser)).toBe(false);
+  });
+  it('should return false if implicit auth enabled and implicit user', () => {
+    expect(isAuthorized(getSettings(true, 'implicit'), codeUser)).toBe(false);
+  });
+  it('should return true if implicit auth enabled and implicit user', () => {
+    expect(isAuthorized(getSettings(true, 'implicit'), implicitUser)).toBe(
+      true,
+    );
   });
 });

--- a/src/lib/utilities/is-authorized.ts
+++ b/src/lib/utilities/is-authorized.ts
@@ -1,5 +1,12 @@
 import type { Settings, User } from '$lib/types/global';
+import { OIDCFlow } from '$lib/types/global';
 
 export const isAuthorized = (settings: Settings, user: User): boolean => {
-  return !settings.auth.enabled || Boolean(user?.accessToken);
+  return (
+    !settings.auth.enabled ||
+    Boolean(
+      (settings.auth.flow == OIDCFlow.AuthorizationCode && user?.accessToken) ||
+        (settings.auth.flow == OIDCFlow.Implicit && user?.idToken),
+    )
+  );
 };

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -129,23 +129,23 @@ const withAuth = async (
   options: RequestInit,
   isBrowser = BROWSER,
 ): Promise<RequestInit> => {
+  const { accessToken, idToken } = getAuthUser();
   if (globalThis?.AccessToken) {
     options.headers = await withBearerToken(
       options?.headers,
       globalThis.AccessToken,
       isBrowser,
     );
-  } else if (getAuthUser().accessToken) {
+  } else if (accessToken || idToken) {
     options.headers = await withBearerToken(
       options?.headers,
-      async () => getAuthUser().accessToken,
+      async () => accessToken ?? idToken,
       isBrowser,
     );
-    options.headers = withIdToken(
-      options?.headers,
-      getAuthUser().idToken,
-      isBrowser,
-    );
+  }
+
+  if (idToken) {
+    options.headers = withIdToken(options?.headers, idToken, isBrowser);
   }
 
   return options;

--- a/src/routes/(app)/+layout.ts
+++ b/src/routes/(app)/+layout.ts
@@ -1,4 +1,6 @@
 import { redirect } from '@sveltejs/kit';
+import { InvalidTokenError, jwtDecode, type JwtPayload } from 'jwt-decode';
+import lscache from 'lscache';
 
 import type { LayoutData, LayoutLoad } from './$types';
 
@@ -8,15 +10,28 @@ import { fetchSettings } from '$lib/services/settings-service';
 import { clearAuthUser, getAuthUser, setAuthUser } from '$lib/stores/auth-user';
 import type { GetClusterInfoResponse, GetSystemInfoResponse } from '$lib/types';
 import type { Settings } from '$lib/types/global';
+import { OIDCFlow } from '$lib/types/global';
 import {
   cleanAuthUserCookie,
   getAuthUserCookie,
 } from '$lib/utilities/auth-user-cookie';
 import { isAuthorized } from '$lib/utilities/is-authorized';
-import { routeForLoginPage } from '$lib/utilities/route-for';
+import {
+  routeForImplicitFlow,
+  routeForLoginPage,
+} from '$lib/utilities/route-for';
 
 import '../../app.css';
 
+lscache.flushExpired();
+
+/**
+ *
+ * @modifies removes the nonce and state from localStorage
+ * @modifies drops the url hash fragment
+ * @throws {Redirect} to address auth and login state
+ *
+ */
 export const load: LayoutLoad = async function ({
   fetch,
 }): Promise<LayoutData> {
@@ -27,13 +42,43 @@ export const load: LayoutLoad = async function ({
     clearAuthUser();
   }
 
-  const authUser = getAuthUserCookie();
-  if (authUser?.accessToken) {
-    setAuthUser(authUser);
-    cleanAuthUserCookie();
+  if (settings.auth.flow == OIDCFlow.AuthorizationCode) {
+    const authUser = getAuthUserCookie();
+    if (authUser?.accessToken) {
+      setAuthUser(authUser, settings.auth.flow);
+      cleanAuthUserCookie();
+    }
+  }
+
+  if (!settings.auth.enabled) {
+    clearAuthUser(); // prevent stale local storage values being passed down
   }
 
   const user = getAuthUser();
+
+  // save the redirect and the click through the login page, iff there is an expired id token.
+  // the login page is still used to display auth errors (e.g. UI proxy)
+  if (user?.idToken) {
+    let token: JwtPayload;
+    try {
+      token = jwtDecode(user.idToken);
+    } catch (e) {
+      if (e instanceof InvalidTokenError) {
+        clearAuthUser();
+      }
+
+      throw e;
+    }
+
+    if (token?.exp && token.exp * 1000 <= Date.now()) {
+      clearAuthUser();
+      const location = new URL(document.location.toString());
+      redirect(
+        302,
+        routeForImplicitFlow(settings, location.searchParams, location.origin),
+      );
+    }
+  }
 
   if (!isAuthorized(settings, user)) {
     redirect(302, routeForLoginPage());

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,10 +1,21 @@
+import { redirect } from '@sveltejs/kit';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import lscache from 'lscache';
 
 import type { LayoutData, LayoutLoad } from './$types';
 
 import { i18nNamespaces } from '$lib/i18n';
 import resources from '$lib/i18n/locales';
+import { fetchSettings } from '$lib/services/settings-service';
+import { setAuthUser } from '$lib/stores/auth-user';
+import type { Settings } from '$lib/types/global';
+import { OIDCFlow } from '$lib/types/global';
+import {
+  maybeRouteForOIDCImplicitCallback,
+  type OIDCCallback,
+  OIDCImplicitCallbackError,
+} from '$lib/utilities/route-for';
 
 export const ssr = false;
 
@@ -22,4 +33,46 @@ export const load: LayoutLoad = async function (): LayoutData {
     },
     resources,
   });
+
+  const settings: Settings = await fetchSettings(fetch);
+
+  if (settings.auth.flow == OIDCFlow.Implicit && window.location.hash) {
+    let callback: OIDCCallback;
+    try {
+      callback = maybeRouteForOIDCImplicitCallback(window.location.hash);
+    } catch (e) {
+      if (e instanceof OIDCImplicitCallbackError) {
+        clearHash();
+      } else {
+        throw e;
+      }
+    }
+
+    if (callback) {
+      clearHash();
+      const { redirectUrl: url, authUser, stateKey } = callback;
+
+      setAuthUser(authUser, settings.auth.flow);
+      localStorage.removeItem('nonce');
+      if (stateKey) {
+        lscache.flush();
+      }
+
+      redirect(302, url);
+    }
+  }
 };
+
+/**
+ *
+ * @modifies drops the url hash
+ *
+ */
+function clearHash() {
+  // known oidc sveltekit issue https://github.com/sveltejs/kit/issues/7271
+  history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search,
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ import { uiServerPlugin } from './plugins/vite-plugin-ui-server';
 
 export default defineConfig({
   plugins: [sveltekit(), temporalServer(), uiServerPlugin()],
+  // for dev
+  // build: {
+  //   minify: false,
+  // },
   optimizeDeps: {
     include: ['date-fns', 'date-fns-tz'],
   },


### PR DESCRIPTION
Backport of https://github.com/DataDog/temporalio-ui/compare/v2.26.0...dd-dev-v2.26.0-oidc-implicit

This PR creates a single commit patch for the SSO functionality. It was created by using a 3-way merge and resolving some Luckily apart of the generated `pnpm-lock.yaml` lock file, the other conflict was in `src/lib/holocene/user-menu.svelte` and caused by some easy to track refactoring. 
Everything else did apply with a 3-way merge. I did not verify the TypeScript and Go itself. I only manually verified that SSO works. 

ASAIK, SSO (implicit OICD flow) is the only patch we apply and the list of commits from above URL stems from the way development was handled and that we went forth and back with a couple of details. 

See also https://datadoghq.atlassian.net/wiki/spaces/ATLAS/pages/3536520417/Temporal+UI+Upgrade